### PR TITLE
Spec description should match intention

### DIFF
--- a/spec/inputs/stdin_spec.rb
+++ b/spec/inputs/stdin_spec.rb
@@ -7,7 +7,7 @@ describe LogStash::Inputs::Stdin do
   context ".reloadable?" do
     subject { described_class }
 
-    it "returns true" do
+    it "returns false" do
       expect(subject.reloadable?).to be_falsey
     end
   end


### PR DESCRIPTION
A small patch here to align the spec description and expectation.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
